### PR TITLE
Harden CI pinning and config/doc consistency

### DIFF
--- a/.github/workflows/fullstack.yml
+++ b/.github/workflows/fullstack.yml
@@ -23,7 +23,7 @@ jobs:
         distribution: 'temurin'
         
     - name: Setup Clojure CLI
-      uses: DeLaGuardo/setup-clojure@master
+      uses: DeLaGuardo/setup-clojure@27f91575da4b554a890f789faf65b6e433162b88
       with:
         cli: latest
         
@@ -127,7 +127,7 @@ jobs:
         distribution: 'temurin'
         
     - name: Setup Clojure CLI
-      uses: DeLaGuardo/setup-clojure@master
+      uses: DeLaGuardo/setup-clojure@27f91575da4b554a890f789faf65b6e433162b88
       with:
         cli: latest
         

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 - [[ESTIMATION]] -> `ESTIMATION.md` - Story points and estimation guidelines
 - [[BUILD]] -> `BUILD.md` - Build/run/watch commands for both frontend and backend
 - [[TESTING]] -> `TESTING.md` - Testing procedures and framework usage
-- [[web/src/__tests__/e2e/README.md]] -> `web/src/__tests__/e2e/README.md` - WebSocket E2E testing guide
+- [`web/src/__tests__/e2e/README.md`](web/src/__tests__/e2e/README.md) - WebSocket E2E testing guide
 - [[LINTING]] -> `LINTING.md` - Code style and static analysis rules
 - [[LOGGING]] -> `LOGGING.md` - Backend logging configuration and best practices
 
@@ -73,7 +73,7 @@
 - Security: treat WS inputs as user-controlled; never trust UI-sent numbers without validation.
 - Performance: profile long-running `sim/tick!` operations before optimizing; measure first.
 - Internationalization: not required yet; keep strings central for future extraction.
-- **Testing**: Run backend tests with `cd backend && clojure -X:test` and frontend tests with `cd web && npm test`. Use `-X:test` for coverage reports. Run WebSocket E2E tests with `cd web && npm run test:websocket:e2e` to validate game fundamentals against a real backend instance.
+- **Testing**: Run backend tests with `cd backend && clojure -X:test`, backend coverage with `cd backend && clojure -X:coverage`, and frontend tests with `cd web && npm test`. Run WebSocket E2E tests with `cd web && npm run test:websocket:e2e` to validate game fundamentals against a real backend instance.
 - **linting** Backend tests are ran with `cd backend && clojure -X:lint`
 
 

--- a/backend/src/fantasia/config.clj
+++ b/backend/src/fantasia/config.clj
@@ -30,6 +30,15 @@
       (log/log-warn "[CONFIG:LOAD-FAILED]" {:path path :error (.getMessage e)})
       nil)))
 
+(defn- deep-merge
+  [left right]
+  (merge-with (fn [x y]
+                (if (and (map? x) (map? y))
+                  (deep-merge x y)
+                  y))
+              (or left {})
+              (or right {})))
+
 (defn get-ollama-config-path
   "Get the path to the Ollama configuration file.
    Checks environment variable OLLAMA_CONFIG_PATH first, then default location."
@@ -42,7 +51,7 @@
   []
   (let [config-path (get-ollama-config-path)
         loaded-config (load-edn-file config-path)
-        merged-config (merge default-ollama-config loaded-config)]
+        merged-config (deep-merge default-ollama-config loaded-config)]
     (if loaded-config
       (log/log-info "[CONFIG:OLLAMA-LOADED]"
                     {:path config-path

--- a/backend/test/fantasia/config_test.clj
+++ b/backend/test/fantasia/config_test.clj
@@ -26,3 +26,16 @@
           primary (config/get-ollama-primary-model cfg)]
       (is (string? primary))
       (is (= primary (get-in cfg [:ollama :primary-model]))))))
+
+(deftest test-load-ollama-config-deep-merges-nested-defaults
+  (testing "Partial nested config preserves unspecified defaults"
+    (let [tmp-file (java.io.File/createTempFile "ollama-config" ".edn")]
+      (try
+        (spit tmp-file "{:ollama {:primary-model \"custom-model\"}}")
+        (let [cfg (with-redefs [config/get-ollama-config-path (constantly (.getAbsolutePath tmp-file))]
+                    (config/load-ollama-config!))]
+          (is (= "custom-model" (get-in cfg [:ollama :primary-model])))
+          (is (= "http://localhost:11434/api/generate" (get-in cfg [:ollama :url])))
+          (is (= "nomic-embed-text" (get-in cfg [:ollama-embed :model]))))
+        (finally
+          (.delete tmp-file))))))

--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -1,0 +1,27 @@
+# Process Reference
+
+This document defines the task lifecycle used by specs and implementation work.
+
+## State Flow
+
+`Incoming -> Accepted -> Breakdown -> Ready -> Todo -> In Progress -> In Review -> Testing -> Document -> Done`
+
+## State Intent
+
+- `Incoming`: New request is captured but not triaged.
+- `Accepted`: The request is approved to be planned.
+- `Breakdown`: The work is decomposed into concrete tasks.
+- `Ready`: Tasks are prepared and scoped for execution.
+- `Todo`: The next executable task is queued.
+- `In Progress`: Active implementation is underway.
+- `In Review`: Changes are ready for code review.
+- `Testing`: Verification is running (tests, lint, build, diagnostics).
+- `Document`: Notes/spec updates are finalized.
+- `Done`: Work is complete and verified.
+
+## Execution Rules
+
+- Keep tasks small and independently mergeable where possible.
+- Do not skip verification before moving to `Done`.
+- If scope expands during `Breakdown`, split before moving to `Ready`.
+- Record outcome notes in the relevant spec or docs entry.

--- a/spec/2026-02-12-pr35-post-merge-hardening-candidates.md
+++ b/spec/2026-02-12-pr35-post-merge-hardening-candidates.md
@@ -8,8 +8,8 @@ tags: [pr-35, follow-up, hardening, reliability]
 related_pr:
   repo: octave-commons/gates-of-aker
   number: 35
-  branch: device/stealth
-process_ref: docs/reference/process.md
+  branch: "device/stealth"
+process_ref: "docs/reference/process.md"
 ---
 
 ## Objective


### PR DESCRIPTION
## Summary
- make the `AGENTS.md` `__tests__` reference render as a literal path and align backend coverage guidance to `clojure -X:coverage`
- pin both `DeLaGuardo/setup-clojure` workflow usages in `.github/workflows/fullstack.yml` to a fixed commit SHA
- switch Ollama config loading to recursive deep merge so nested defaults are preserved for partial config files
- add a regression test for nested config merge behavior, and fix post-merge hardening spec references including a concrete `docs/reference/process.md`

## Validation
- `cd backend && clojure -X:test`
- `pnpm run typecheck` (via pre-push hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling to properly preserve and combine nested settings with defaults instead of overwriting them entirely.

* **Documentation**
  * Added process documentation outlining task lifecycle and state flow.
  * Enhanced developer workflow documentation with backend test coverage execution steps.

* **Tests**
  * Added test coverage for configuration deep-merge behavior with nested defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->