### PR TITLE
Add eta-mu GitHub workflows

### DIFF
--- a/.github/workflows/eta-mu-review-gate.yml
+++ b/.github/workflows/eta-mu-review-gate.yml
@@ -1,0 +1,50 @@
+name: eta-mu-review-gate
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  coderabbit-review-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+
+      - name: Checkout eta-mu logic
+        uses: actions/checkout@v4
+        with:
+          repository: open-hax/eta-mu-github
+          path: .eta-mu
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: .eta-mu/pnpm-lock.yaml
+
+      - name: Install eta-mu dependencies
+        run: pnpm --dir .eta-mu install --frozen-lockfile
+
+      - name: Enforce review-thread resolution for configured actors
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ETA_MU_REVIEW_ACTORS: ${{ vars.ETA_MU_REVIEW_ACTORS }}
+        run: >-
+          pnpm --dir .eta-mu dev review-gate
+          --repo "${GITHUB_REPOSITORY}"
+          --pr "${{ github.event.pull_request.number }}"

--- a/.github/workflows/eta-mu-review-gate.yml
+++ b/.github/workflows/eta-mu-review-gate.yml
@@ -17,21 +17,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Checkout eta-mu logic
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: open-hax/eta-mu-github
+          ref: 7e63b18cd5fa0dec31491de07f14b22a4851bcc0
           path: .eta-mu
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: 10.14.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/eta-mu.yml
+++ b/.github/workflows/eta-mu.yml
@@ -1,0 +1,80 @@
+name: eta-mu
+
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: eta-mu-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  eta-mu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout eta-mu logic
+        uses: actions/checkout@v4
+        with:
+          repository: open-hax/eta-mu-github
+          path: .eta-mu
+
+      - name: Create eta-mu app token
+        id: eta_mu_token
+        if: ${{ secrets.ETA_MU_APP_ID != '' && secrets.ETA_MU_APP_PRIVATE_KEY != '' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ETA_MU_APP_ID }}
+          private-key: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: .eta-mu/pnpm-lock.yaml
+
+      - name: Install eta-mu dependencies
+        run: pnpm --dir .eta-mu install --frozen-lockfile
+
+      - name: Run eta-mu event handler
+        env:
+          GITHUB_TOKEN: ${{ steps.eta_mu_token.outputs.token != '' && steps.eta_mu_token.outputs.token || github.token }}
+          ETA_MU_APP_ID: ${{ secrets.ETA_MU_APP_ID }}
+          ETA_MU_APP_PRIVATE_KEY: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
+          ETA_MU_MODEL_PROVIDER: ${{ vars.ETA_MU_MODEL_PROVIDER }}
+          ETA_MU_MODEL_ID: ${{ vars.ETA_MU_MODEL_ID }}
+          ETA_MU_REVIEW_ACTORS: ${{ vars.ETA_MU_REVIEW_ACTORS }}
+          ETA_MU_MENTION_TOKENS: ${{ vars.ETA_MU_MENTION_TOKENS }}
+          ETA_MU_IGNORE_LOGINS: ${{ vars.ETA_MU_IGNORE_LOGINS }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: >-
+          pnpm --dir .eta-mu dev run-event
+          --repo "${GITHUB_REPOSITORY}"
+          --event-name "${GITHUB_EVENT_NAME}"
+          --event-path "${GITHUB_EVENT_PATH}"
+          --cwd "$PWD"

--- a/.github/workflows/eta-mu.yml
+++ b/.github/workflows/eta-mu.yml
@@ -24,33 +24,41 @@ concurrency:
 jobs:
   eta-mu:
     runs-on: ubuntu-latest
+    env:
+      ETA_MU_APP_ID_PRESENT: ${{ secrets.ETA_MU_APP_ID != '' }}
+      ETA_MU_APP_PRIVATE_KEY_PRESENT: ${{ secrets.ETA_MU_APP_PRIVATE_KEY != '' }}
+      ETA_MU_MODEL_PROVIDER_PRESENT: ${{ vars.ETA_MU_MODEL_PROVIDER != '' }}
+      OPENAI_API_KEY_PRESENT: ${{ secrets.OPENAI_API_KEY != '' }}
+      ANTHROPIC_API_KEY_PRESENT: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+      GEMINI_API_KEY_PRESENT: ${{ secrets.GEMINI_API_KEY != '' }}
     steps:
       - name: Checkout target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
       - name: Checkout eta-mu logic
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: open-hax/eta-mu-github
+          ref: 7e63b18cd5fa0dec31491de07f14b22a4851bcc0
           path: .eta-mu
 
       - name: Create eta-mu app token
         id: eta_mu_token
-        if: ${{ secrets.ETA_MU_APP_ID != '' && secrets.ETA_MU_APP_PRIVATE_KEY != '' }}
-        uses: actions/create-github-app-token@v1
+        if: ${{ env.ETA_MU_APP_ID_PRESENT == 'true' && env.ETA_MU_APP_PRIVATE_KEY_PRESENT == 'true' }}
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
         with:
           app-id: ${{ secrets.ETA_MU_APP_ID }}
           private-key: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: 10.14.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
@@ -60,6 +68,7 @@ jobs:
         run: pnpm --dir .eta-mu install --frozen-lockfile
 
       - name: Run eta-mu event handler
+        if: ${{ env.ETA_MU_MODEL_PROVIDER_PRESENT == 'true' || env.OPENAI_API_KEY_PRESENT == 'true' || env.ANTHROPIC_API_KEY_PRESENT == 'true' || env.GEMINI_API_KEY_PRESENT == 'true' }}
         env:
           GITHUB_TOKEN: ${{ steps.eta_mu_token.outputs.token != '' && steps.eta_mu_token.outputs.token || github.token }}
           ETA_MU_APP_ID: ${{ secrets.ETA_MU_APP_ID }}


### PR DESCRIPTION
## Summary
- add the shared `eta-mu` event workflow wrapper
- add the `eta-mu-review-gate` workflow so unresolved CodeRabbit review threads can become a required merge gate

## Notes
- intended required check context: `coderabbit-review-gate`
- intended branch protection still relies on native review-thread resolution as well
- rollout source: `octave-commons/gates-of-aker` via devel automation